### PR TITLE
Error on invalid cell types while parsing

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
 import { Blocks, JupyterNotebook } from '@curvenote/blocks';
-import { notebookFromJupyter, translateFromJupyter } from './translators';
+import { notebookFromJupyter, translateFromJupyter, translators } from './translators';
 import { TranslatedBlockPair } from './types';
 
 /**
@@ -12,16 +12,18 @@ export const parseNotebook = (
   notebook: Partial<Blocks.Notebook>;
   children: TranslatedBlockPair[];
 } => {
-  const children: TranslatedBlockPair[] = notebookAsJson.cells.map((cell) => {
-    const [content, output] = translateFromJupyter(
-      cell,
-      notebookAsJson.metadata.language_info.name,
-    );
-    if (!output || (output as Blocks.Output)?.original?.length === 0) {
-      return { content } as TranslatedBlockPair;
-    }
-    return { content, output } as TranslatedBlockPair;
-  });
+  const children: TranslatedBlockPair[] = notebookAsJson.cells
+    .filter((cell) => translators[cell.cell_type])
+    .map((cell) => {
+      const [content, output] = translateFromJupyter(
+        cell,
+        notebookAsJson.metadata.language_info.name,
+      );
+      if (!output || (output as Blocks.Output)?.original?.length === 0) {
+        return { content } as TranslatedBlockPair;
+      }
+      return { content, output } as TranslatedBlockPair;
+    });
 
   const notebook = notebookFromJupyter(notebookAsJson);
 

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,5 +1,5 @@
 import { Blocks, JupyterNotebook } from '@curvenote/blocks';
-import { notebookFromJupyter, translateFromJupyter, translators } from './translators';
+import { notebookFromJupyter, translateFromJupyter } from './translators';
 import { TranslatedBlockPair } from './types';
 
 /**
@@ -12,18 +12,16 @@ export const parseNotebook = (
   notebook: Partial<Blocks.Notebook>;
   children: TranslatedBlockPair[];
 } => {
-  const children: TranslatedBlockPair[] = notebookAsJson.cells
-    .filter((cell) => translators[cell.cell_type])
-    .map((cell) => {
-      const [content, output] = translateFromJupyter(
-        cell,
-        notebookAsJson.metadata.language_info.name,
-      );
-      if (!output || (output as Blocks.Output)?.original?.length === 0) {
-        return { content } as TranslatedBlockPair;
-      }
-      return { content, output } as TranslatedBlockPair;
-    });
+  const children: TranslatedBlockPair[] = notebookAsJson.cells.map((cell) => {
+    const [content, output] = translateFromJupyter(
+      cell,
+      notebookAsJson.metadata.language_info.name,
+    );
+    if (!output || (output as Blocks.Output)?.original?.length === 0) {
+      return { content } as TranslatedBlockPair;
+    }
+    return { content, output } as TranslatedBlockPair;
+  });
 
   const notebook = notebookFromJupyter(notebookAsJson);
 

--- a/src/translators/index.ts
+++ b/src/translators/index.ts
@@ -65,5 +65,8 @@ export function translateFromJupyter(
   cell: NotebookCell,
   language: Language | undefined,
 ): (Blocks.Code | Blocks.Content | Blocks.Output)[] {
+  if (!translators[cell.cell_type]) {
+    throw Error(`Unknown cell_type: ${cell.cell_type}`);
+  }
   return translators[cell.cell_type].fromJupyter(cell, language);
 }

--- a/test/parseNotebook.spec.ts
+++ b/test/parseNotebook.spec.ts
@@ -24,20 +24,9 @@ describe('processing.notebook', () => {
     });
 
     test('parse notebook with invalid cell', () => {
-      const invalidCellNotebook = { ...exampleNotebookAsJson }
-      invalidCellNotebook.cells = [{} as any, ...invalidCellNotebook.cells]
-      const { notebook, children } = parseNotebook(invalidCellNotebook as JupyterNotebook);
-
-      expect(notebook).toBeDefined();
-      expect(notebook.kind).toEqual(KINDS.Notebook);
-      expect(notebook.language).toEqual('python');
-      expect(notebook).toHaveProperty('metadata');
-      expect(notebook.order).toEqual([]);
-      expect(notebook.children).toEqual({});
-
-      expect(children).toBeDefined();
-      expect(children).toHaveLength(7);
-      expect(children.filter((b) => b.output)).toHaveLength(2);
+      const invalidCellNotebook = { ...exampleNotebookAsJson };
+      invalidCellNotebook.cells = [{} as any, ...invalidCellNotebook.cells];
+      expect(() => parseNotebook(invalidCellNotebook as JupyterNotebook)).toThrow();
     });
   });
 });

--- a/test/parseNotebook.spec.ts
+++ b/test/parseNotebook.spec.ts
@@ -22,5 +22,22 @@ describe('processing.notebook', () => {
       expect(children).toHaveLength(7);
       expect(children.filter((b) => b.output)).toHaveLength(2);
     });
+
+    test('parse notebook with invalid cell', () => {
+      const invalidCellNotebook = { ...exampleNotebookAsJson }
+      invalidCellNotebook.cells = [{} as any, ...invalidCellNotebook.cells]
+      const { notebook, children } = parseNotebook(invalidCellNotebook as JupyterNotebook);
+
+      expect(notebook).toBeDefined();
+      expect(notebook.kind).toEqual(KINDS.Notebook);
+      expect(notebook.language).toEqual('python');
+      expect(notebook).toHaveProperty('metadata');
+      expect(notebook.order).toEqual([]);
+      expect(notebook.children).toEqual({});
+
+      expect(children).toBeDefined();
+      expect(children).toHaveLength(7);
+      expect(children.filter((b) => b.output)).toHaveLength(2);
+    });
   });
 });


### PR DESCRIPTION
I had in invalid (empty `{}`) cell in a notebook - ~I _think_ this happened when I edited it in curvenote~ - and got this error: 
![image](https://user-images.githubusercontent.com/9453731/172523850-33224839-ec64-4ac4-98dd-5a37c8bd70fa.png)

This PR changes parse notebook behaviour to ignore cells with unknown or nonexistent `cell_type`