### PR TITLE
🐛 Remove base64 if it is included in the data for IOutputs

### DIFF
--- a/src/minify/convert.ts
+++ b/src/minify/convert.ts
@@ -43,7 +43,12 @@ export function convertToIOutputs(
                 console.debug(`${mimetype} is not json parsable, leaving as is`);
               }
             }
-            if (content && !mimetype.startsWith('image/svg') && mimetype.startsWith('image/')) {
+            if (
+              content &&
+              !mimetype.startsWith('image/svg') &&
+              mimetype.startsWith('image/') &&
+              !((content as string).startsWith('data:') && (content as string).includes(';base64,'))
+            ) {
               content = `data:${mimetype};base64,${content}`;
             }
 

--- a/src/minify/convert.ts
+++ b/src/minify/convert.ts
@@ -43,13 +43,18 @@ export function convertToIOutputs(
                 console.debug(`${mimetype} is not json parsable, leaving as is`);
               }
             }
+
+            // Jupyter outputs are just the base64 encoded data without the the "header" of "data:image/png;base64,"
+            // If the header is included, this strips it out.
             if (
               content &&
-              !mimetype.startsWith('image/svg') &&
               mimetype.startsWith('image/') &&
-              !((content as string).startsWith('data:') && (content as string).includes(';base64,'))
+              !mimetype.startsWith('image/svg') &&
+              (content as string).startsWith('data:') &&
+              (content as string).includes(';base64,')
             ) {
-              content = `data:${mimetype};base64,${content}`;
+              const [data] = content.split(';base64,').reverse(); // reverse is just to be bug-free!
+              content = data;
             }
 
             if (!content) return acc;

--- a/test/minify.convert.spec.ts
+++ b/test/minify.convert.spec.ts
@@ -21,16 +21,9 @@ describe('minify.convert', () => {
       'execute_result',
       '<div><article><h1>Hello World</h1><p>Welcome to the future</p></article></div>',
     ],
-    [
-      'image/gif',
-      'execute_result',
-      'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
-    ],
-    [
-      'image/png',
-      'execute_result',
-      'data:image/png;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
-    ],
+    // Note that the results for base64 encoded data does not include the "header" of "data:image/png;base64,"
+    ['image/gif', 'execute_result', 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'],
+    ['image/png', 'execute_result', 'R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'],
     ['application/json', 'execute_result', { some: { json: 'object' } }],
   ])(
     'minifyMimeOutput - single %s',


### PR DESCRIPTION
This is a bug fix when testing existing content. I have had to tweak for some of the hydration of base64 images.