### PR TITLE
🕵🏽‍♀️ Remove the crypto dependency

### DIFF
--- a/.changeset/dirty-melons-impress.md
+++ b/.changeset/dirty-melons-impress.md
@@ -1,0 +1,5 @@
+---
+'nbtx': patch
+---
+
+Remove the dependence on `crypto` node library

--- a/README.md
+++ b/README.md
@@ -38,10 +38,13 @@ The following example loads a notebook, then iterates through each cell and, if 
 
 ```typescript
 import fs from 'fs';
-import { minifyCellOutput, MinifiedContentCache } from 'nbtx';
+import type { MinifiedContentCache, MinifyOptions } from 'nbtx';
+import { minifyCellOutput } from 'nbtx';
 
 const notebook = JSON.parse(fs.readFileSync('my-notebook.ipynb'));
 const outputCache: MinifiedContentCache = {};
+// Options for minification, see note on hashing below
+const opts: Partial<MinifyOptions> = { computeHash };
 
 notebook.cells.forEach((cell) => {
   if (!cell.outputs?.length) return;
@@ -81,6 +84,21 @@ notebook.cells.forEach((cell) => {
 > **Note**
 > Minifying and restoring notebook outputs may change the structure of output text from a string list to a single,
 > new-line-delimited string. Both of these formats are acceptable in the notebook types defined by `nbformat`.
+
+## Hashing function
+
+To be able to have no dependencies and also run easily in the browser, `nbtx` does not bundle a hashing library.
+To create the `computeHash` function, choose an algorithm, for example, `md5` and digest the content. If you are in the browser, consider using `crypto-js` or some other random function.
+
+```typescript
+import { createHash } from 'crypto';
+
+function computeHash(content: string): string {
+  return createHash('md5').update(content).digest('hex');
+}
+```
+
+By default `nbtx` will create a random string for the hash and raise a warning.
 
 ## Data transformation example
 

--- a/src/minify/mime.ts
+++ b/src/minify/mime.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-param-reassign */
 import type { IDisplayData, IExecuteResult, MultilineString } from '@jupyterlab/nbformat';
 import type { MinifiedContentCache, MinifiedMimeBundle, MinifyOptions } from './types';
-import { computeHash, ensureString } from './utils';
+import { ensureString } from './utils';
 
 function minifyContent(
   content: string,
@@ -16,10 +16,10 @@ function minifyContent(
   let hash: string;
   if (isBase64Image) {
     const [data] = content.split(';base64,').reverse(); // reverse as sometimes there is no header
-    hash = computeHash(data);
+    hash = opts.computeHash(data);
     outputCache[hash] = [data, { contentType, encoding: 'base64' }];
   } else {
-    hash = computeHash(content);
+    hash = opts.computeHash(content);
     outputCache[hash] = [content, { contentType, encoding: 'utf8' }];
   }
   return {

--- a/src/minify/minify.ts
+++ b/src/minify/minify.ts
@@ -2,7 +2,7 @@ import type { IOutput, IStream, IError, IDisplayData, IExecuteResult } from '@ju
 import { minifyMimeOutput } from './mime';
 import { minifyErrorOutput, minifyStreamOutput } from './text';
 import type { MinifiedContentCache, MinifiedOutput, MinifyOptions } from './types';
-import { isNotNull, MAX_CHARS, TRUNCATED_CHARS_COUNT } from './utils';
+import { DEFAULT_HASH_WARNING, isNotNull, MAX_CHARS, TRUNCATED_CHARS_COUNT } from './utils';
 
 async function minifyOneOutputItem(
   output: IOutput,
@@ -41,6 +41,7 @@ export async function minifyCellOutput(
   const options = {
     maxCharacters: opts.maxCharacters ?? MAX_CHARS,
     truncateTo: opts.truncateTo ?? TRUNCATED_CHARS_COUNT,
+    computeHash: opts.computeHash ?? DEFAULT_HASH_WARNING,
   };
   const minifiedOrNull = await Promise.all(
     outputs.map(async (output) => minifyOneOutputItem(output, outputCache, options)),

--- a/src/minify/text.ts
+++ b/src/minify/text.ts
@@ -6,7 +6,7 @@ import type {
   MinifiedStreamOutput,
   MinifyOptions,
 } from './types';
-import { computeHash, ensureString } from './utils';
+import { ensureString } from './utils';
 
 function ensureStringEnsureNewlines(maybeString: string | string[] | undefined) {
   return typeof maybeString === 'string'
@@ -29,7 +29,7 @@ async function minifyStringOutput(
   if (text && text.length <= opts.maxCharacters) {
     return { ...(output as any), [fieldName]: text };
   }
-  const hash = computeHash(text);
+  const hash = opts.computeHash(text);
   outputCache[hash] = [text, { contentType: 'text/plain', encoding: 'utf8' }];
   return {
     ...(output as any),

--- a/src/minify/types.ts
+++ b/src/minify/types.ts
@@ -3,6 +3,7 @@ import type { IStream, IError, ExecutionCount, OutputMetadata } from '@jupyterla
 export interface MinifyOptions {
   maxCharacters: number;
   truncateTo: number;
+  computeHash: (content: string) => string;
 }
 
 export type MinifiedStreamOutput = { hash?: string; path?: string } & IStream;

--- a/src/minify/utils.ts
+++ b/src/minify/utils.ts
@@ -1,4 +1,3 @@
-import { createHash } from 'crypto';
 import type {
   MinifiedErrorOutput,
   MinifiedMimeBundle,
@@ -9,6 +8,14 @@ import type {
 
 export const MAX_CHARS = 25000;
 export const TRUNCATED_CHARS_COUNT = 64;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function DEFAULT_HASH_WARNING(content: string): string {
+  console.warn(
+    'nbtx is not using a hashing library to create the hash.\nThe IDs generated are random, please provide a createHash function, for example from "crypto".\nSee nbtx README for more information.',
+  );
+  return `not-a-hash-${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
+}
 
 export function isNotNull<T>(arg: T | null): arg is T {
   return arg != null;
@@ -36,10 +43,6 @@ export function walkOutputs(
       func(output as MinifiedStreamOutput | MinifiedErrorOutput);
     }
   });
-}
-
-export function computeHash(content: string) {
-  return createHash('md5').update(content).digest('hex');
 }
 
 export function ensureString(maybeString: string[] | string | undefined, joinWith = ''): string {

--- a/src/minify/utils.ts
+++ b/src/minify/utils.ts
@@ -12,7 +12,7 @@ export const TRUNCATED_CHARS_COUNT = 64;
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function DEFAULT_HASH_WARNING(content: string): string {
   console.warn(
-    'nbtx is not using a hashing library to create the hash.\nThe IDs generated are random, please provide a createHash function, for example from "crypto".\nSee nbtx README for more information.',
+    'nbtx is not using a hashing library to create the hash.\nThe IDs generated are random, please provide a `computeHash` function, for example using "crypto".\nSee nbtx README for more information.',
   );
   return `not-a-hash-${Math.random().toString(36).slice(2)}${Math.random().toString(36).slice(2)}`;
 }

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,4 +1,9 @@
+import { createHash } from 'crypto';
 import type { IDisplayData, IError, IExecuteResult, IStream } from '@jupyterlab/nbformat';
+
+export function computeHash(content: string) {
+  return createHash('md5').update(content).digest('hex');
+}
 
 export function makeNativeStreamOutput(text?: string | string[]) {
   return {

--- a/test/minify.convert.spec.ts
+++ b/test/minify.convert.spec.ts
@@ -1,12 +1,18 @@
 import { convertToIOutputs, minifyCellOutput } from '../src/minify';
 import { minifyMimeOutput } from '../src/minify/mime';
 import { minifyErrorOutput, minifyStreamOutput } from '../src/minify/text';
-import { MinifiedContentCache } from '../src/minify/types';
-import { makeNativeErrorOutput, makeNativeMimeOutput, makeNativeStreamOutput } from './helpers';
+import type { MinifiedContentCache } from '../src/minify/types';
+import {
+  makeNativeErrorOutput,
+  makeNativeMimeOutput,
+  makeNativeStreamOutput,
+  computeHash,
+} from './helpers';
 
 const default_opts = {
   maxCharacters: 20,
   truncateTo: 10,
+  computeHash,
 };
 
 describe('minify.convert', () => {

--- a/test/minify.mime.spec.ts
+++ b/test/minify.mime.spec.ts
@@ -1,11 +1,11 @@
 import { minifyMimeOutput } from '../src/minify/mime';
-import { MinifiedContentCache } from '../src/minify/types';
-import { computeHash } from '../src/minify/utils';
-import { makeNativeMimeOutput } from './helpers';
+import type { MinifiedContentCache } from '../src/minify/types';
+import { computeHash, makeNativeMimeOutput } from './helpers';
 
 const default_opts = {
   maxCharacters: 20,
   truncateTo: 10,
+  computeHash,
 };
 
 describe('minify.mime', () => {
@@ -74,5 +74,7 @@ describe('minify.mime', () => {
       ]);
     },
   );
-  test('minifyMimeOutput - multiple %s', () => {});
+  test('minifyMimeOutput - multiple %s', () => {
+    //pass
+  });
 });

--- a/test/minify.text.spec.ts
+++ b/test/minify.text.spec.ts
@@ -1,11 +1,11 @@
 import { minifyStreamOutput, minifyErrorOutput } from '../src/minify/text';
-import { MinifiedContentCache } from '../src/minify/types';
-import { computeHash } from '../src/minify/utils';
-import { makeNativeErrorOutput, makeNativeStreamOutput } from './helpers';
+import type { MinifiedContentCache } from '../src/minify/types';
+import { computeHash, makeNativeErrorOutput, makeNativeStreamOutput } from './helpers';
 
 const default_opts = {
   maxCharacters: 20,
   truncateTo: 10,
+  computeHash,
 };
 
 describe('minify.text', () => {


### PR DESCRIPTION
To be able to have no dependencies and also run easily in the browser, `nbtx` does not bundle a hashing library.
To create the `computeHash` function, choose an algorithm, for example, `md5` and digest the content. If you are in the browser, consider using `crypto-js` or some other random function.

```typescript
import { createHash } from 'crypto';

function computeHash(content: string): string {
  return createHash('md5').update(content).digest('hex');
}
```

By default `nbtx` will create a random string for the hash and raise a warning.