### PR TITLE
zero length content not moved to path

### DIFF
--- a/.changeset/rude-doors-act.md
+++ b/.changeset/rude-doors-act.md
@@ -1,0 +1,5 @@
+---
+'nbtx': minor
+---
+
+Some vendor mime-bundles resolve to a string, and should not be pushed to file no matter the maxCharacters setting.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v4
         with:
           node-version: 22.x
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: 'node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 22.x
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
           path: 'node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('yarn.lock') }}
-      - run: yarn install
-      - run: yarn run lint
-      - run: yarn run lint:format
-      - run: yarn run test
+          key: ${{ runner.os }}-modules-${{ hashFiles('package-lock.json') }}
+      - run: npm install
+      - run: npm run lint
+      - run: npm run lint:format
+      - run: npm run test

--- a/src/minify/mime.ts
+++ b/src/minify/mime.ts
@@ -10,7 +10,11 @@ function minifyContent(
   outputCache: MinifiedContentCache,
   opts: MinifyOptions,
 ) {
-  if (!isBase64Image && content && content.length <= opts.maxCharacters) {
+  console.log('minifyContent', content, contentType, isBase64Image, outputCache, opts);
+  if (content.length === 0) {
+    return { content, content_type: contentType };
+  }
+  if (!isBase64Image && content.length <= opts.maxCharacters) {
     return { content, content_type: contentType };
   }
   let hash: string;

--- a/src/minify/mime.ts
+++ b/src/minify/mime.ts
@@ -10,11 +10,7 @@ function minifyContent(
   outputCache: MinifiedContentCache,
   opts: MinifyOptions,
 ) {
-  console.log('minifyContent', content, contentType, isBase64Image, outputCache, opts);
-  if (content.length === 0) {
-    return { content, content_type: contentType };
-  }
-  if (!isBase64Image && content.length <= opts.maxCharacters) {
+  if (content.length === 0 || (!isBase64Image && content.length <= opts.maxCharacters)) {
     return { content, content_type: contentType };
   }
   let hash: string;

--- a/test/minify.mime.spec.ts
+++ b/test/minify.mime.spec.ts
@@ -3,7 +3,7 @@ import type { MinifiedContentCache } from '../src/minify/types';
 import { computeHash, makeNativeMimeOutput } from './helpers';
 
 const default_opts = {
-  maxCharacters: 20,
+  maxCharacters: 200,
   truncateTo: 10,
   computeHash,
 };
@@ -74,6 +74,22 @@ describe('minify.mime', () => {
       ]);
     },
   );
+  test.only('minifyMimeOutput - no minify %s', async () => {
+    const output = makeNativeMimeOutput('execute_result', 'application/vnd.holoviews+json', '');
+    expect(Object.keys(output.data)).toEqual(['application/vnd.holoviews+json']);
+    const cache = {} as MinifiedContentCache;
+    const minified = await minifyMimeOutput(output, cache, default_opts);
+    expect(minified).toEqual({
+      data: {
+        'application/vnd.holoviews+json': {
+          content: '',
+          content_type: 'application/vnd.holoviews+json',
+        },
+      },
+      metadata: { meta: 'data' },
+      output_type: 'execute_result',
+    });
+  });
   test('minifyMimeOutput - multiple %s', () => {
     //pass
   });

--- a/test/minify.mime.spec.ts
+++ b/test/minify.mime.spec.ts
@@ -74,7 +74,7 @@ describe('minify.mime', () => {
       ]);
     },
   );
-  test.only('minifyMimeOutput - no minify %s', async () => {
+  test('minifyMimeOutput - no minify %s', async () => {
     const output = makeNativeMimeOutput('execute_result', 'application/vnd.holoviews+json', '');
     expect(Object.keys(output.data)).toEqual(['application/vnd.holoviews+json']);
     const cache = {} as MinifiedContentCache;

--- a/test/minify.mime.spec.ts
+++ b/test/minify.mime.spec.ts
@@ -3,7 +3,7 @@ import type { MinifiedContentCache } from '../src/minify/types';
 import { computeHash, makeNativeMimeOutput } from './helpers';
 
 const default_opts = {
-  maxCharacters: 200,
+  maxCharacters: 20,
   truncateTo: 10,
   computeHash,
 };


### PR DESCRIPTION
Some vendor mime-bundles resolve to a string, and should not be pushed to file no matter the maxCharacters setting.
